### PR TITLE
Added compatibility for the more complex SCTE-224 Any values.

### DIFF
--- a/types/scte224v20151115/sctestructures.go
+++ b/types/scte224v20151115/sctestructures.go
@@ -154,30 +154,30 @@ type Assert struct {
 //Table 11
 type Policy struct {
 	ReusableType
-	XMLName        xml.Name         `xml:"http://www.scte.org/schemas/224/2015 Policy"`
+	XMLName        xml.Name         `xml:"http://www.scte.org/schemas/224/2015 Policy,omitempty"`
 	ViewingPolicys []*ViewingPolicy `xml:"http://www.scte.org/schemas/224/2015 ViewingPolicy,omitempty"`
+}
+
+type AnyProperty struct {
+	XMLName xml.Name
+	Data    string `xml:",innerxml"`
 }
 
 //Table 12
 type ViewingPolicy struct {
 	ReusableType
-	XMLName  xml.Name  `xml:"http://www.scte.org/schemas/224/2015 ViewingPolicy"`
-	Audience *Audience `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
-	Any
+	XMLName        xml.Name      `xml:"http://www.scte.org/schemas/224/2015 ViewingPolicy,omitempty"`
+	Audience       *Audience     `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
+	ActionProperty []AnyProperty `xml:",any"`
 }
 
 //Table 13
 type Audience struct {
 	ReusableType
-	XMLName   xml.Name    `xml:"http://www.scte.org/schemas/224/2015 Audience"`
-	Match     Match       `xml:"match,attr,omitempty"`
-	Audiences []*Audience `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
-	Any
-}
-
-type Any struct {
-	XMLName  xml.Name `xml:"http://www.scte.org/schemas/224 Any,omitempty" json:"-"`
-	InnerXml string   `xml:",innerxml" json:"anys,omitempty"`
+	XMLName          xml.Name      `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
+	Match            Match         `xml:"match,attr,omitempty"`
+	Audiences        []*Audience   `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
+	AudienceProperty []AnyProperty `xml:",any"`
 }
 
 //********************* Results Types *************************//

--- a/types/scte224v20151115/sctestructures.go
+++ b/types/scte224v20151115/sctestructures.go
@@ -158,26 +158,26 @@ type Policy struct {
 	ViewingPolicys []*ViewingPolicy `xml:"http://www.scte.org/schemas/224/2015 ViewingPolicy,omitempty"`
 }
 
-type AnyProperty struct {
-	XMLName xml.Name
-	Data    string `xml:",chardata"`
-}
-
 //Table 12
 type ViewingPolicy struct {
 	ReusableType
-	XMLName        xml.Name      `xml:"http://www.scte.org/schemas/224/2015 ViewingPolicy"`
-	Audience       *Audience     `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
-	ActionProperty []AnyProperty `xml:",any"`
+	XMLName  xml.Name  `xml:"http://www.scte.org/schemas/224/2015 ViewingPolicy"`
+	Audience *Audience `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
+	Any
 }
 
 //Table 13
 type Audience struct {
 	ReusableType
-	XMLName          xml.Name      `xml:"http://www.scte.org/schemas/224/2015 Audience"`
-	Match            Match         `xml:"match,attr,omitempty"`
-	Audiences        []*Audience   `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
-	AudienceProperty []AnyProperty `xml:",any"`
+	XMLName   xml.Name    `xml:"http://www.scte.org/schemas/224/2015 Audience"`
+	Match     Match       `xml:"match,attr,omitempty"`
+	Audiences []*Audience `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
+	Any
+}
+
+type Any struct {
+	XMLName  xml.Name `xml:"http://www.scte.org/schemas/224 Any,omitempty" json:"-"`
+	InnerXml string   `xml:",innerxml" json:"anys,omitempty"`
 }
 
 //********************* Results Types *************************//

--- a/types/scte224v20151115/sctestructures.go
+++ b/types/scte224v20151115/sctestructures.go
@@ -154,7 +154,7 @@ type Assert struct {
 //Table 11
 type Policy struct {
 	ReusableType
-	XMLName        xml.Name         `xml:"http://www.scte.org/schemas/224/2015 Policy,omitempty"`
+	XMLName        xml.Name         `xml:"http://www.scte.org/schemas/224/2015 Policy"`
 	ViewingPolicys []*ViewingPolicy `xml:"http://www.scte.org/schemas/224/2015 ViewingPolicy,omitempty"`
 }
 
@@ -166,7 +166,7 @@ type AnyProperty struct {
 //Table 12
 type ViewingPolicy struct {
 	ReusableType
-	XMLName        xml.Name      `xml:"http://www.scte.org/schemas/224/2015 ViewingPolicy,omitempty"`
+	XMLName        xml.Name      `xml:"http://www.scte.org/schemas/224/2015 ViewingPolicy"`
 	Audience       *Audience     `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
 	ActionProperty []AnyProperty `xml:",any"`
 }
@@ -174,7 +174,7 @@ type ViewingPolicy struct {
 //Table 13
 type Audience struct {
 	ReusableType
-	XMLName          xml.Name      `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
+	XMLName          xml.Name      `xml:"http://www.scte.org/schemas/224/2015 Audience"`
 	Match            Match         `xml:"match,attr,omitempty"`
 	Audiences        []*Audience   `xml:"http://www.scte.org/schemas/224/2015 Audience,omitempty"`
 	AudienceProperty []AnyProperty `xml:",any"`

--- a/types/scte224v20151115/sctestructures_test.go
+++ b/types/scte224v20151115/sctestructures_test.go
@@ -1,0 +1,125 @@
+package scte224v20151115
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+const viewingpolicy string = `
+<?xml version="1.0" encoding="utf-8"?>
+<ViewingPolicy 
+	xmlns:action="urn:scte:224:action" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:audience="urn:scte:224:audience" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xmlns:metadata="urn:scte:224:metadata" id="test.com/viewingpolicy/test" lastUpdated="2019-02-22T16:03:19.907Z" 
+  xmlns="http://www.scte.org/schemas/224/2015">
+	<Audience xlink:href="test.com/audience/all" />
+	<action:Content>TARGETSTREAM</action:Content>
+  <action:FastForward>false</action:FastForward>
+  <action:Capture>
+    <action:StartWindow>
+      <action:Percentage>0</action:Percentage>
+    </action:StartWindow>
+    <action:StopWindow>
+      <action:Percentage>250</action:Percentage>
+    </action:StopWindow>
+    <action:MidrollDAI>false</action:MidrollDAI>
+  </action:Capture>
+</ViewingPolicy>`
+
+type testViewingPolicy struct {
+	ReusableType
+	ActionProperty []*AnyProperty `xml:"http://www.scte.org/schemas/224/2015 Any,omitempty"`
+	XMLName        xml.Name       `xml:"http://www.scte.org/schemas/224/2015 ViewingPolicy"`
+	Audience       *Audience      `xml:"http://www.scte.org/schemas/224/2015 Audience"`
+	FastForward    string         `xml:"FastForward,omitempty"`
+	Capture        []*testCapture `xml:"Capture,omitempty"`
+	Content        string         `xml:"Content,omitempty"`
+}
+
+//Capture struct
+type testCapture struct {
+	StartWindow *testStartWindow `xml:"StartWindow,omitempty"`
+	StopWindow  *testStopWindow  `xml:"StopWindow,omitempty"`
+	MidrollDAI  string           `xml:"MidrollDAI,omitempty"`
+}
+
+//StartWindow struct
+type testStartWindow struct {
+	Percentage string `xml:"Percentage,omitempty"`
+}
+
+//StopWindow struct
+type testStopWindow struct {
+	Offset     string `xml:"Offset,omitempty"`
+	Percentage string `xml:"Percentage,omitempty"`
+}
+
+func TestViewingPolicy2015(t *testing.T) {
+
+	var vpol *ViewingPolicy
+	err := xml.Unmarshal([]byte(viewingpolicy), &vpol)
+	if err != nil {
+		t.Errorf("Error unmarshalling viewingpolicys %v", err)
+		t.FailNow()
+	}
+
+	vbyte, marshalErr := xml.Marshal(vpol)
+	if marshalErr != nil {
+		t.Errorf("Error Marshal %v", err)
+		t.FailNow()
+	}
+
+	var tvpol *testViewingPolicy
+	err = xml.Unmarshal(vbyte, &tvpol)
+	if err != nil {
+		t.Errorf("Error unmarshalling %v", err)
+		t.FailNow()
+	}
+
+	if tvpol.FastForward == "" {
+		t.Log("action:FastForward is empty")
+		t.FailNow()
+	}
+
+	if tvpol.Content == "" {
+		t.Log("action:Content is empty")
+		t.FailNow()
+	}
+
+	// Capture
+	if len(tvpol.Capture) == 0 {
+		t.Log("action:Capture is empty and is supposed to have child nodes")
+		t.FailNow()
+	}
+
+	for _, capture := range tvpol.Capture {
+		// StartWindow
+		if capture.StartWindow == nil {
+			t.Log("action:Capture StartWindow is nil")
+			t.FailNow()
+		}
+		if capture.StartWindow.Percentage == "" {
+			t.Log("action:Capture StartWindow Percentage is empty")
+			t.Fail()
+		}
+
+		// StopWindow
+		if capture.StopWindow == nil {
+			t.Log("action:Capture StopWindow is nil")
+			t.FailNow()
+		}
+
+		if capture.StopWindow.Percentage == "" {
+			t.Log("action:Capture StopWindow Percentage is empty")
+			t.Fail()
+		}
+
+		// MidrollDAI
+		if capture.MidrollDAI == "" {
+			t.Log("action:Capture MidrollDAI is empty")
+			t.Fail()
+		}
+	}
+}

--- a/types/scte224v20180501/sctestructures.go
+++ b/types/scte224v20180501/sctestructures.go
@@ -180,26 +180,26 @@ type Policy struct {
 	ViewingPolicys []*ViewingPolicy `xml:"http://www.scte.org/schemas/224 ViewingPolicy,omitempty" json:"viewingPolicys,omitempty"`
 }
 
-type AnyProperty struct {
-	XMLName xml.Name
-	Data    string `xml:",chardata" json:"data,omitempty"`
-}
-
 //Table 12
 type ViewingPolicy struct {
 	ReusableType
-	XMLName        xml.Name      `xml:"http://www.scte.org/schemas/224 ViewingPolicy" json:"-"`
-	Audience       *Audience     `xml:"http://www.scte.org/schemas/224 Audience,omitempty" json:"audience,omitempty"`
-	ActionProperty []AnyProperty `xml:",any" json:"actionProperty,omitempty"`
+	XMLName  xml.Name  `xml:"http://www.scte.org/schemas/224 ViewingPolicy" json:"-"`
+	Audience *Audience `xml:"http://www.scte.org/schemas/224 Audience,omitempty" json:"audience,omitempty"`
+	Any
 }
 
 //Table 13
 type Audience struct {
 	ReusableType
-	XMLName          xml.Name      `xml:"http://www.scte.org/schemas/224 Audience" json:"-"`
-	Match            Match         `xml:"match,attr,omitempty" json:"match,omitempty"`
-	Audiences        []*Audience   `xml:"http://www.scte.org/schemas/224 Audience,omitempty" json:"audiences,omitempty"`
-	AudienceProperty []AnyProperty `xml:",any" json:"audienceProperty,omitempty"`
+	XMLName   xml.Name    `xml:"http://www.scte.org/schemas/224 Audience" json:"-"`
+	Match     Match       `xml:"match,attr,omitempty" json:"match,omitempty"`
+	Audiences []*Audience `xml:"http://www.scte.org/schemas/224 Audience,omitempty" json:"audiences,omitempty"`
+	Any
+}
+
+type Any struct {
+	XMLName  xml.Name `xml:"http://www.scte.org/schemas/224 Any,omitempty" json:"-"`
+	InnerXml string   `xml:",innerxml" json:"anys,omitempty"`
 }
 
 //********************* Results Types *************************//

--- a/types/scte224v20180501/sctestructures_test.go
+++ b/types/scte224v20180501/sctestructures_test.go
@@ -1,0 +1,125 @@
+package scte224v20180501
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+const viewingpolicy string = `
+<?xml version="1.0" encoding="utf-8"?>
+<ViewingPolicy 
+	xmlns:action="urn:scte:224:action" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:audience="urn:scte:224:audience" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xmlns:metadata="urn:scte:224:metadata" id="test.com/viewingpolicy/test" lastUpdated="2019-02-22T16:03:19.907Z" 
+  xmlns="http://www.scte.org/schemas/224">
+  <Audience xlink:href="test.com/audience/all" />
+	<action:FastForward>false</action:FastForward>
+	<action:Content>TARGETSTREAM</action:Content>
+  <action:Capture>
+    <action:StartWindow>
+      <action:Percentage>0</action:Percentage>
+    </action:StartWindow>
+    <action:StopWindow>
+      <action:Percentage>250</action:Percentage>
+    </action:StopWindow>
+    <action:MidrollDAI>false</action:MidrollDAI>
+  </action:Capture>
+</ViewingPolicy>`
+
+type testViewingPolicy struct {
+	ReusableType
+	ActionProperty []*AnyProperty `xml:"http://www.scte.org/schemas/224 Any,omitempty" json:"anys,omitempty"`
+	XMLName        xml.Name       `xml:"http://www.scte.org/schemas/224 ViewingPolicy" json:"-"`
+	Audience       *Audience      `xml:"http://www.scte.org/schemas/224 Audience" json:"audience,omitempty"`
+	FastForward    string         `xml:"FastForward,omitempty" json:"fastForward,omitempty"`
+	Capture        []*testCapture `xml:"Capture,omitempty" "json:"capture,omitempty"`
+	Content        string         `xml:"Content,omitempty" "json:"content,omitempty"`
+}
+
+//Capture struct
+type testCapture struct {
+	StartWindow *testStartWindow `xml:"StartWindow,omitempty" json:"startWindow"`
+	StopWindow  *testStopWindow  `xml:"StopWindow,omitempty" json:"stopWindow"`
+	MidrollDAI  string           `xml:"MidrollDAI,omitempty" json:"midrollDAI"`
+}
+
+//StartWindow struct
+type testStartWindow struct {
+	Percentage string `xml:"Percentage,omitempty" json:"percentage"`
+}
+
+//StopWindow struct
+type testStopWindow struct {
+	Offset     string `xml:"Offset,omitempty" json:"offset"`
+	Percentage string `xml:"Percentage,omitempty" json:"percentage"`
+}
+
+func TestViewingPolicy2018(t *testing.T) {
+
+	var vpol *ViewingPolicy
+	err := xml.Unmarshal([]byte(viewingpolicy), &vpol)
+	if err != nil {
+		t.Errorf("Error unmarshalling viewingpolicys %v", err)
+		t.FailNow()
+	}
+
+	vbyte, marshalErr := xml.Marshal(vpol)
+	if marshalErr != nil {
+		t.Errorf("Error Marshal %v", err)
+		t.FailNow()
+	}
+
+	var tvpol *testViewingPolicy
+	err = xml.Unmarshal(vbyte, &tvpol)
+	if err != nil {
+		t.Errorf("Error unmarshalling %v", err)
+		t.FailNow()
+	}
+
+	if tvpol.FastForward == "" {
+		t.Log("action:FastForward is empty")
+		t.FailNow()
+	}
+
+	if tvpol.Content == "" {
+		t.Log("action:Content is empty")
+		t.FailNow()
+	}
+
+	// Capture
+	if len(tvpol.Capture) == 0 {
+		t.Log("action:Capture is empty and is supposed to have child nodes")
+		t.FailNow()
+	}
+
+	for _, capture := range tvpol.Capture {
+		// StartWindow
+		if capture.StartWindow == nil {
+			t.Log("action:Capture StartWindow is nil")
+			t.FailNow()
+		}
+		if capture.StartWindow.Percentage == "" {
+			t.Log("action:Capture StartWindow Percentage is empty")
+			t.Fail()
+		}
+
+		// StopWindow
+		if capture.StopWindow == nil {
+			t.Log("action:Capture StopWindow is nil")
+			t.FailNow()
+		}
+
+		if capture.StopWindow.Percentage == "" {
+			t.Log("action:Capture StopWindow Percentage is empty")
+			t.Fail()
+		}
+
+		// MidrollDAI
+		if capture.MidrollDAI == "" {
+			t.Log("action:Capture MidrollDAI is empty")
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
Example with `action:Capture` :

```
<?xml version="1.0" encoding="utf-8"?>
<ViewingPolicy xmlns:action="urn:scte:224:action" 
  xmlns:xlink="http://www.w3.org/1999/xlink" 
  xmlns:audience="urn:scte:224:audience" 
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xmlns:metadata="urn:scte:224:metadata" id="test.com/viewingpolicy/test" lastUpdated="2019-02-22T16:03:19.907Z" 
  xmlns="http://www.scte.org/schemas/224">
  <Audience xlink:href="test.com/audience/all" />
  <action:FastForward>false</action:FastForward>
  <action:Capture>
    <action:StartWindow>
      <action:Percentage>0</action:Percentage>
    </action:StartWindow>
    <action:StopWindow>
      <action:Percentage>250</action:Percentage>
    </action:StopWindow>
    <action:MidrollDAI>false</action:MidrollDAI>
  </action:Capture>
</ViewingPolicy>
```

The current struct drops the contents of capture. This pull request will fix this.