### PR TITLE
Update Metadata & Ext to be a list of object to match .xsd definition

### DIFF
--- a/types/scte224v20151115/sctestructures.go
+++ b/types/scte224v20151115/sctestructures.go
@@ -20,7 +20,7 @@ type IdentifiableType struct {
 	XMLBase     string     `xml:"xml:base,attr,omitempty"`
 	AltIDs      []*AltID   `xml:"http://www.scte.org/schemas/224/2015 AltID,omitempty"`
 	Metadata    *Metadata  `xml:"http://www.scte.org/schemas/224/2015 Metadata,omitempty"`
-	Ext         *Metadata  `xml:"http://www.scte.org/schemas/224/2015 Ext,omitempty"`
+	Ext         *Ext       `xml:"http://www.scte.org/schemas/224 Ext,omitempty" json:"ext,omitempty"`
 }
 
 //Table 5
@@ -60,7 +60,19 @@ type MediaPoint struct {
 }
 
 type Metadata struct {
-	InnerXml string `xml:",innerxml"`
+	XMLName xml.Name `xml:"http://www.scte.org/schemas/224 Metadata" json:"-"`
+	Nodes   []Any    `xml:",any" json:"values,omitempty"`
+}
+
+type Ext struct {
+	XMLName xml.Name `xml:"http://www.scte.org/schemas/224 Ext"`
+	Nodes   []Any    `xml:",any" json:"values,omitempty"`
+}
+
+type Any struct {
+	XMLName    xml.Name   `json:"xmlname"`
+	Attributes []xml.Attr `xml:",any,attr"`
+	Value      string     `xml:",chardata" json:"value"`
 }
 
 type Duration string

--- a/types/scte224v20151115/sctestructures.go
+++ b/types/scte224v20151115/sctestructures.go
@@ -20,7 +20,7 @@ type IdentifiableType struct {
 	XMLBase     string     `xml:"xml:base,attr,omitempty"`
 	AltIDs      []*AltID   `xml:"http://www.scte.org/schemas/224/2015 AltID,omitempty"`
 	Metadata    *Metadata  `xml:"http://www.scte.org/schemas/224/2015 Metadata,omitempty"`
-	Ext         *Ext       `xml:"http://www.scte.org/schemas/224/2015 Ext,omitempty" json:"ext,omitempty"`
+	Ext         *Ext       `xml:"http://www.scte.org/schemas/224/2015 Ext,omitempty"`
 }
 
 //Table 5

--- a/types/scte224v20151115/sctestructures.go
+++ b/types/scte224v20151115/sctestructures.go
@@ -20,7 +20,7 @@ type IdentifiableType struct {
 	XMLBase     string     `xml:"xml:base,attr,omitempty"`
 	AltIDs      []*AltID   `xml:"http://www.scte.org/schemas/224/2015 AltID,omitempty"`
 	Metadata    *Metadata  `xml:"http://www.scte.org/schemas/224/2015 Metadata,omitempty"`
-	Ext         *Ext       `xml:"http://www.scte.org/schemas/224 Ext,omitempty" json:"ext,omitempty"`
+	Ext         *Ext       `xml:"http://www.scte.org/schemas/224/2015 Ext,omitempty" json:"ext,omitempty"`
 }
 
 //Table 5

--- a/types/scte224v20151115/sctestructures.go
+++ b/types/scte224v20151115/sctestructures.go
@@ -60,12 +60,12 @@ type MediaPoint struct {
 }
 
 type Metadata struct {
-	XMLName xml.Name `xml:"http://www.scte.org/schemas/224 Metadata" json:"-"`
+	XMLName xml.Name `xml:"http://www.scte.org/schemas/224/2015 Metadata" json:"-"`
 	Nodes   []Any    `xml:",any" json:"values,omitempty"`
 }
 
 type Ext struct {
-	XMLName xml.Name `xml:"http://www.scte.org/schemas/224 Ext"`
+	XMLName xml.Name `xml:"http://www.scte.org/schemas/224/2015 Ext"`
 	Nodes   []Any    `xml:",any" json:"values,omitempty"`
 }
 

--- a/types/scte224v20180501/sctestructures.go
+++ b/types/scte224v20180501/sctestructures.go
@@ -20,7 +20,7 @@ type IdentifiableType struct {
 	XMLBase     string     `xml:"xml:base,attr,omitempty" json:"-"`
 	AltIDs      []*AltID   `xml:"http://www.scte.org/schemas/224 AltID,omitempty" json:"altIDs,omitempty"`
 	Metadata    *Metadata  `xml:"http://www.scte.org/schemas/224 Metadata,omitempty" json:"metadata,omitempty"`
-	Ext         *Metadata  `xml:"http://www.scte.org/schemas/224 Ext,omitempty" json:"ext,omitempty"`
+	Ext         *Ext       `xml:"http://www.scte.org/schemas/224 Ext,omitempty" json:"ext,omitempty"`
 }
 
 //Table 5
@@ -71,7 +71,19 @@ func (mp *MediaPoint) GetOrder() uint {
 }
 
 type Metadata struct {
-	InnerXml string `xml:",innerxml" json:"innerXml,omitempty"`
+	XMLName xml.Name `xml:"http://www.scte.org/schemas/224 Metadata" json:"-"`
+	Nodes   []Any    `xml:",any" json:"values,omitempty"`
+}
+
+type Ext struct {
+	XMLName xml.Name `xml:"http://www.scte.org/schemas/224 Ext"`
+	Nodes   []Any    `xml:",any" json:"values,omitempty"`
+}
+
+type Any struct {
+	XMLName    xml.Name   `json:"xmlname"`
+	Attributes []xml.Attr `xml:",any,attr"`
+	Value      string     `xml:",chardata" json:"value"`
 }
 
 type Duration string

--- a/types/scte224v20180501/sctestructures_test.go
+++ b/types/scte224v20180501/sctestructures_test.go
@@ -60,6 +60,17 @@ func TestViewingPolicy2018(t *testing.T) {
 
 	var vpol *ViewingPolicy
 	err := xml.Unmarshal([]byte(viewingpolicy), &vpol)
+
+	//mybytes, myerr := xml.Marshal(vpol)
+	//if myerr != nil {
+	//	t.Errorf("Error marshalling viewingpolicys %v", myerr)
+	//	t.FailNow()
+	//}
+	//
+	//mystring := string(mybytes)
+	//
+	//fmt.Print(mystring)
+
 	if err != nil {
 		t.Errorf("Error unmarshalling viewingpolicys %v", err)
 		t.FailNow()
@@ -122,4 +133,66 @@ func TestViewingPolicy2018(t *testing.T) {
 			t.Fail()
 		}
 	}
+}
+
+const mediapoint string = `
+<MediaPoint xmlns="http://www.scte.org/schemas/224" description="Avail Start" effective="2016-07-05T14:59:50Z"
+       expectedDuration="PT30S" expires="2016-07-05T15:10:00Z" id="providerXYZ.com/media/break/1234/start" matchTime="2016-07-05T15:00:00Z">
+   <AltID description="Ad-ID">CNPA0484000H</AltID>
+   <Metadata>
+       <metadata DAIModel="SINGLE_ADVERTISER" duration="PT30S" offset="PT0S" ownerName="XYZ" ownerType="PROVIDER"/>
+       <metadata DAIModel="DOUBLE_ADVERTISER" duration="PT30S" offset="PT30S" ownerName="ABCD" ownerType="DISTRIBUTOR"/>
+   </Metadata>
+   <Apply duration="PT30S">
+       <Policy/>
+   </Apply>
+</MediaPoint>`
+
+func TestMediaPointMetadata(t *testing.T) {
+
+	var mp *MediaPoint
+	err := xml.Unmarshal([]byte(mediapoint), &mp)
+	if err != nil {
+		t.Errorf("Error unmarshalling mediapoint %v", err)
+		t.FailNow()
+	}
+
+	metadata := mp.Metadata
+	if metadata == nil {
+		t.Log("unexpected nil metadata")
+		t.FailNow()
+	}
+
+	nodes := metadata.Nodes
+	if nodes == nil {
+		t.Log("unexpected nil nodes")
+		t.FailNow()
+	}
+
+	if len(nodes) != 2 {
+		t.Log("unexpected exactly 2 nodes")
+		t.FailNow()
+	}
+
+	attributes := nodes[0].Attributes
+	if attributes == nil {
+		t.Log("unexpected nil attributes")
+		t.FailNow()
+	}
+
+	if len(attributes) != 5 {
+		t.Log("unexpected exactly 5 node attributes")
+		t.FailNow()
+	}
+
+	attr1 := attributes[0]
+	if attr1.Name.Local != "DAIModel" {
+		t.Errorf("unexpected attribute name %v", attr1.Name.Local)
+		t.FailNow()
+	}
+	if attr1.Value != "SINGLE_ADVERTISER" {
+		t.Errorf("unexpected attribute value %v", attr1.Value)
+		t.FailNow()
+	}
+
 }

--- a/types/scte224v20180501/sctestructures_test.go
+++ b/types/scte224v20180501/sctestructures_test.go
@@ -61,16 +61,6 @@ func TestViewingPolicy2018(t *testing.T) {
 	var vpol *ViewingPolicy
 	err := xml.Unmarshal([]byte(viewingpolicy), &vpol)
 
-	//mybytes, myerr := xml.Marshal(vpol)
-	//if myerr != nil {
-	//	t.Errorf("Error marshalling viewingpolicys %v", myerr)
-	//	t.FailNow()
-	//}
-	//
-	//mystring := string(mybytes)
-	//
-	//fmt.Print(mystring)
-
 	if err != nil {
 		t.Errorf("Error unmarshalling viewingpolicys %v", err)
 		t.FailNow()


### PR DESCRIPTION
Metadata should allow multiple values, per defn from: scte.org/schemas/224/SCTE224-20180501.xsd

Also it should be re-confirmed that namespace definitions are correct.  (e.g. does Metadata tag need explicit namespace defn)