### PR TITLE
Setting Rating/@RatingSystem to be omitted if empty.

### DIFF
--- a/types/scte224v20180501/adi30/adi30.go
+++ b/types/scte224v20180501/adi30/adi30.go
@@ -167,7 +167,7 @@ type ExtAppData struct {
 }
 
 type Rating struct {
-	RatingSystem string `xml:"ratingSystem,attr"`
+	RatingSystem string `xml:"ratingSystem,attr,omitempty"`
 	Value        string `xml:",chardata"`
 }
 


### PR DESCRIPTION
Current implementation would always add a `ratingSystem=""` attribute, which causes XML validation failures.  The XSDs do not call this attribute out as mandatory.