### PR TITLE
Add SegmentationEventId field

### DIFF
--- a/types/scte224v20180501/sctestructures.go
+++ b/types/scte224v20180501/sctestructures.go
@@ -228,6 +228,7 @@ type SignalPointInsertionAction struct {
 
 type SignalPoint struct {
 	Offset               Duration   `xml:"offset,attr,omitempty" json:"offset,omitempty"`
+	SegmentationEventId  string     `xml:"segmentationEventId,attr,omitempty" json:"segmentationEventId,omitempty"`
 	SegmentationTypeId   *uint      `xml:"segmentationTypeId,attr,omitempty" json:"segmentationTypeId,omitempty"`
 	SegmentationUpidType *uint      `xml:"segmentationUpidType,attr,omitempty" json:"segmentationUpidType,omitempty"`
 	SegmentationUpid     string     `xml:"segmentationUpid,attr,omitempty" json:"segmentationUpid,omitempty"`

--- a/types/scte224v20200407/avp.go
+++ b/types/scte224v20200407/avp.go
@@ -84,6 +84,7 @@ func (vp *ViewingPolicy) Get2018() scte224_2018.ViewingPolicy {
 
 			signalPoints2018 = append(signalPoints2018, &scte224_2018.SignalPoint{
 				Offset:               scte224_2018.Duration(signalPoint.Offset),
+				SegmentationEventId:  signalPoint.SegmentationEventId,
 				SegmentationTypeId:   signalPoint.SegmentationTypeId,
 				SegmentationUpidType: signalPoint.SegmentationUpidType,
 				SegmentationUpid:     signalPoint.SegmentationUpid,
@@ -194,6 +195,7 @@ type SignalPointInsertionAction struct {
 
 type SignalPoint struct {
 	Offset               Duration   `xml:"offset,attr,omitempty" json:"offset,omitempty"`
+	SegmentationEventId  string     `xml:"segmentationEventId,attr,omitempty" json:"segmentationEventId,omitempty"`
 	SegmentationTypeId   *uint      `xml:"segmentationTypeId,attr,omitempty" json:"segmentationTypeId,omitempty"`
 	SegmentationUpidType *uint      `xml:"segmentationUpidType,attr,omitempty" json:"segmentationUpidType,omitempty"`
 	SegmentationUpid     string     `xml:"segmentationUpid,attr,omitempty" json:"segmentationUpid,omitempty"`

--- a/types/scte224v20200407/avp_test.go
+++ b/types/scte224v20200407/avp_test.go
@@ -35,6 +35,23 @@ func TestViewingPolicyDowngrade_w_SIS(t *testing.T) {
 	assert.EqualValues(t, vpSignalPointInsertion_w_SpliceInfoSection, string(vp2018Marshaled), "Downgrade failed")
 }
 
+func TestUnmarhalViewingPolicy_PPOStart(t *testing.T) {
+	var vp *ViewingPolicy
+	err := xml.Unmarshal([]byte(vpPPOStart), &vp)
+	assert.Nil(t, err, "Error unmarshalling viewingpolicy")
+}
+
+func TestViewingPolicyDowngrade_PPOStart(t *testing.T) {
+	var vp *ViewingPolicy
+	err := xml.Unmarshal([]byte(vpPPOStart), &vp)
+	assert.Nil(t, err, "Error unmarshalling viewingpolicy")
+
+	vp2018 := vp.Get2018()
+	vp2018Marshaled, err := xml.MarshalIndent(vp2018, "", "  ")
+	assert.Nil(t, err, "Error marshaling downgraded viewingpolicy")
+	assert.EqualValues(t, vpPPOStart, string(vp2018Marshaled), "Downgrade failed")
+}
+
 func TestAudienceDowngrade(t *testing.T) {
 	var aud Audience
 	err := xml.Unmarshal([]byte(aud2020Raw), &aud)

--- a/types/scte224v20200407/constants_test.go
+++ b/types/scte224v20200407/constants_test.go
@@ -48,6 +48,13 @@ const vpSignalPointInsertion_w_SpliceInfoSection string = `<ViewingPolicy xmlns=
   </SignalPointReplacement>
 </ViewingPolicy>`
 
+const vpPPOStart string = `<ViewingPolicy xmlns="http://www.scte.org/schemas/224" id="evertz/viewingpolicy/37/GETTV/GET_COM202395/ppostart" description="GET_COM202395 PPO viewing policy start" lastUpdated="2024-01-31T23:52:34.266Z">
+  <Audience xmlns="http://www.scte.org/schemas/224" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="evertz/audience/GETTV/all"></Audience>
+  <SignalPointInsertion xmlns="urn:scte:224:action">
+    <SignalPoint xmlns="urn:scte:224:action" segmentationEventId="123456" segmentationTypeId="52"></SignalPoint>
+  </SignalPointInsertion>
+</ViewingPolicy>`
+
 // Same as "vp2020Raw" but without the additional "Allocation" action
 const vp2018Raw string = `<ViewingPolicy xmlns="http://www.scte.org/schemas/224" id="test/program" description="test program" lastUpdated="2021-01-19T18:49:26.298986528Z">
     <Content xmlns="urn:scte:224:action">CONTENT</Content>


### PR DESCRIPTION
Adding SegmentationEventId field to SignalPoint structure to allow this attribute to be defined rather than just generated.